### PR TITLE
Fixes factorybot configuration

### DIFF
--- a/DTR.md
+++ b/DTR.md
@@ -1,0 +1,34 @@
+### Template for DTR Memo
+
+
+
+Project Expectations: What does each group member hope to get out of this project?
+J - be able to build API, understand JSON
+M - Passing grades
+
+Goals and expectations:
+We'd like to finish and have a working API
+
+Schedule Expectations (When are we available to work together and individually?):
+J - free all week. Prefer to work at night. Would prefer to leave early on Tuesday.
+M - Free all week, generally work in the mornings, not after 10 pm. Tuesday and Thursday lunch won't work for me.
+
+Communication Expectations (How and often will we communicate? How do we keep lines of communication open?):
+Slack. We'll be checking in the mornings.
+
+Workflow Expectations (Git workflow/Tools/Code Review/Reviewing Pull Requests):
+We're ok not doing rebasing.
+M will set up and take responsibility for Waffle. 
+
+Expectations for giving and receiving feedback:
+
+Agenda to discuss project launch:
+Monday: J & M want to work on record endpoint, relation endpoint and BI endpoint simultaneously,
+Tuesday: We'd like to address the rake task/data implementation on Tuesday
+Thursday afternoon: done with the project.
+
+Ideas:
+
+Tools:
+
+Additional Notes:

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
-  gem 'factory_bot'
+  gem 'factory_bot_rails'
   gem 'simplecov'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,9 @@ GEM
     erubi (1.7.1)
     factory_bot (4.8.2)
       activesupport (>= 3.0.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
+      railties (>= 3.0.0)
     ffi (1.9.23)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -150,7 +153,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  factory_bot
+  factory_bot_rails
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 3.7)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ SimpleCov.start do
   add_filter '/app/controllers/'
 end
 
+require_relative './support/factory_bot'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
@@ -26,7 +27,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,4 @@
+require 'factory_bot_rails'
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
There were a few more components to FB setup, namely the /support/factory_bot.rb file, Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f } in the rails helper file, and also changed the gem ('factory_bot' to 'factory_bot_rails') to match what's in the lesson plan.