### PR TITLE
adds serializer and refactors local test for GET /api/v1/merchants/:id/revenue

### DIFF
--- a/app/controllers/api/v1/merchants/revenue_controller.rb
+++ b/app/controllers/api/v1/merchants/revenue_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::Merchants::RevenueController < ApplicationController
   def show
-    render json: Merchant.single_revenue.find(params[:id]).revenue
+    render json: Merchant.single_revenue.find(params[:id]).revenue, serializer: MerchantRevenueSerializer
   end
 end

--- a/app/serializers/merchant_revenue_serializer.rb
+++ b/app/serializers/merchant_revenue_serializer.rb
@@ -1,0 +1,7 @@
+class MerchantRevenueSerializer < ActiveModel::Serializer
+  attributes :revenue
+
+  def revenue
+    (object/100.0).to_s
+  end
+end

--- a/spec/requests/api/v1/merchants/merchant_business_intelligence_spec.rb
+++ b/spec/requests/api/v1/merchants/merchant_business_intelligence_spec.rb
@@ -1,18 +1,20 @@
 require 'rails_helper'
 
 describe 'Merchant API business intelligence' do
-   skip 'returns revenue for a specific merchant' do
+   it 'returns revenue for a specific merchant' do
     merchant = create(:merchant)
+    item = merchant.items.create!(attributes_for(:item))
     customer = create(:customer)
-    invoice = create(:invoice_with_transactions, customer: customer, merchant: merchant)
-
+    invoice = create(:invoice, customer: customer, merchant: merchant)
+    invoice.transactions.create!(attributes_for(:transaction))
+    invoice.invoice_items.create!(attributes_for(:invoice_item, item_id: item.id, quantity: 1, unit_price: 1200))
 
     get "/api/v1/merchants/#{merchant.id}/revenue"
 
     merchant_revenue = JSON.parse(response.body)
 
     expect(response).to be_success
-
+    expect(merchant_revenue['revenue']).to eq('12.0')
   end
 
   it 'returns specified number of merchants with the most items' do


### PR DESCRIPTION
- test_loads_the_total_revenue_across_all_transactions_associated_with_one_merchant passes in spec harness
! we may want to rename merchantrevenueserializer eventually since there'll be an all merchants revenue method. 